### PR TITLE
1 python packaging broken

### DIFF
--- a/ldm/__init__.py
+++ b/ldm/__init__.py
@@ -1,0 +1,4 @@
+from .models import *
+from .data import *
+from .modules import *
+from .util import *

--- a/ldm/modules/__init__.py
+++ b/ldm/modules/__init__.py
@@ -1,0 +1,8 @@
+from .image_degradation import *
+from .diffusionmodules import *
+from .distributions import *
+from .encoders import *
+from .midas import *
+
+from .attention import *
+from .ema import *

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 from setuptools import setup, find_packages
 
-setup(
-    name='stable-diffusion',
-    version='0.0.1',
-    description='',
-    packages=find_packages(),
-    install_requires=[
-        'torch',
-        'numpy',
-        'tqdm',
-    ],
-)
+
+if __name__=='__main__':
+    setup(
+        name='ldm',
+        version='1.0.0',
+        description='Latent diffusion models',
+        packages=find_packages(exclude=('test',)),
+        install_requires=[
+            'torch',
+            'numpy',
+            'tqdm',
+        ],
+    )


### PR DESCRIPTION
Fixes #1.

The ldm module can now be compiled to a wheel and installed via `python setup.py install bdist_wheel`